### PR TITLE
I suggest adding one command to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM hexletbasics/base-image:latest
 
+RUN apt-get update -y
 RUN apt-get install -y default-jdk
 
 RUN curl -L https://github.com/checkstyle/checkstyle/releases/download/checkstyle-8.31/checkstyle-8.31-all.jar > /opt/checkstyle.jar


### PR DESCRIPTION
Without the “RUN apt-get update” command, the following error occurs when building the image:

```
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/n/nss/libnss3_3.49.1-1ubuntu1.1_amd64.deb  404  Not Found [IP: 91.189.88.152 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
ERROR: Service 'exercises' failed to build: The command '/bin/sh -c apt-get install -y default-jdk' returned a non-zero code: 100
make: *** [Makefile:9: compose-build] Error 1

```