### PR TITLE
Fix test output

### DIFF
--- a/modules/35-methods-using/115-string-immutability/Test.java
+++ b/modules/35-methods-using/115-string-immutability/Test.java
@@ -14,7 +14,11 @@ class Test {
 
         App.main(null);
 
-        final var actual = out.toString().trim();
+        var actual = out.toString();
+
+        if (actual.endsWith(System.lineSeparator())) { // delete a newline character because println adds one
+            actual = actual.substring(0, actual.length() - System.lineSeparator().length());
+        }
 
         System.setOut(new PrintStream(new FileOutputStream(FileDescriptor.out)));
         System.out.println(actual);


### PR DESCRIPTION
Ранее тест обрезал строку вывода, которая не охватывала сценарий при котором пользователь не присваивает значение переменной email. Теперь символ новой строки из выходных данных ByteArrayOutputStream удаляется явно с помощью substring и System.LineSeparator() для обеспечения корректности.