### PR TITLE
Update Dockerfile: JDK 25 LTS via Temurin, bump tooling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,35 @@
+# syntax=docker/dockerfile:1
 FROM hexletbasics/base-image:latest
 
 ENV COURSE_DIR=/exercises-java
 
 WORKDIR ${COURSE_DIR}
 
-ENV PATH=${COURSE_DIR}/bin:$PATH
+# JDK ставим из Eclipse Temurin tarball, а не через apt: в базовом образе
+# (Debian bookworm) apt предлагает только openjdk-17, поэтому LTS 25 берём
+# напрямую из Adoptium. Подход не зависит от дистрибутива базы и multi-arch.
+ARG JDK_VERSION=25
+ENV JAVA_HOME=/opt/jdk
+ENV PATH=${COURSE_DIR}/bin:${JAVA_HOME}/bin:$PATH
 
-RUN apt-get update && apt-get install -yqq openjdk-21-jdk \
-  && rm -rf /var/lib/apt/lists/*
+RUN ARCH=$(dpkg --print-architecture) \
+  && case "$ARCH" in \
+       amd64) JARCH=x64 ;; \
+       arm64) JARCH=aarch64 ;; \
+       *) echo "unsupported arch: $ARCH" && exit 1 ;; \
+     esac \
+  && mkdir -p ${JAVA_HOME} \
+  && curl -fsSL "https://api.adoptium.net/v3/binary/latest/${JDK_VERSION}/ga/linux/${JARCH}/jdk/hotspot/normal/eclipse" -o /tmp/jdk.tar.gz \
+  && tar -xzf /tmp/jdk.tar.gz -C ${JAVA_HOME} --strip-components=1 \
+  && rm /tmp/jdk.tar.gz
 
-ENV CHECKSTYLE_VERSION=11.0.1
-RUN curl -L https://github.com/checkstyle/checkstyle/releases/download/checkstyle-${CHECKSTYLE_VERSION}/checkstyle-${CHECKSTYLE_VERSION}-all.jar > /opt/checkstyle.jar
-RUN chmod 777 /opt/checkstyle.jar
+ARG CHECKSTYLE_VERSION=13.6.0
+ARG ASSERTJ_VERSION=3.27.7
+ARG COMMONS_LANG3_VERSION=3.20.0
 
-ENV ASSERTJ_VERSION=3.27.4
-
-RUN curl -L https://repo1.maven.org/maven2/org/assertj/assertj-core/${ASSERTJ_VERSION}/assertj-core-${ASSERTJ_VERSION}.jar > /opt/assertj.jar
-RUN chmod 777 /opt/assertj.jar
-
-ENV COMMONS_LANG3_VERSION=3.18.0
-RUN curl -L https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/${COMMONS_LANG3_VERSION}/commons-lang3-${COMMONS_LANG3_VERSION}.jar > /opt/commons_lang3.jar
-RUN chmod 777 /opt/commons_lang3.jar
+RUN curl -L https://github.com/checkstyle/checkstyle/releases/download/checkstyle-${CHECKSTYLE_VERSION}/checkstyle-${CHECKSTYLE_VERSION}-all.jar -o /opt/checkstyle.jar \
+  && curl -L https://repo1.maven.org/maven2/org/assertj/assertj-core/${ASSERTJ_VERSION}/assertj-core-${ASSERTJ_VERSION}.jar -o /opt/assertj.jar \
+  && curl -L https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/${COMMONS_LANG3_VERSION}/commons-lang3-${COMMONS_LANG3_VERSION}.jar -o /opt/commons_lang3.jar \
+  && chmod 644 /opt/checkstyle.jar /opt/assertj.jar /opt/commons_lang3.jar
 
 COPY . .


### PR DESCRIPTION
- install JDK from Eclipse Temurin tarball (base-image bookworm apt only ships openjdk-17), multi-arch via dpkg --print-architecture
- bump Checkstyle 11.0.1 -> 13.6.0, AssertJ 3.27.4 -> 3.27.7, Commons Lang3 3.18.0 -> 3.20.0
- move versions to ARG, enable BuildKit syntax, merge curl/chmod layers